### PR TITLE
Add poetry as entrypoint within pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,44 +24,44 @@ repos:
     hooks:
       - id: codespell
         name: codespell
-        entry: codespell
+        entry: poetry run codespell
         language: system
         types_or: [python, rst, markdown]
         files: ^src/
 
       - id: isort
         name: isort
-        entry: isort
+        entry: poetry run isort
         language: system
         files: ^src/
 
       - id: pyupgrade
         name: pyupgrade
-        entry: pyupgrade
+        entry: poetry run pyupgrade
         language: system
         args: [--py310-plus]
         files: ^src/
 
       - id: yesqa
         name: yesqa
-        entry: yesqa
+        entry: poetry run yesqa
         language: system
         files: ^src/
 
       - id: black
         name: black
-        entry: black
+        entry: poetry run black
         language: system
         files: ^src/
 
       - id: ruff
         name: ruff
-        entry: ruff
+        entry: poetry run ruff
         language: system
         files: ^src/
 
       - id: flake8
         name: flake8
-        entry: flake8
+        entry: poetry run flake8
         language: system
         files: ^src/


### PR DESCRIPTION
Your approach does not work when you try to commit changes, only when you run `pre-commit` using `make` command (which uses poetry repo). After I commit changes, git hook triggers pre-commit which uses my local environment, instead of poetry one, and that causes an error - e.g. `Executable `codespell` not found`.

I've introduced a change that will keep pre-commit triggered by git hook, use poetry environment. The only issue that I've noticed is that checks are being ran in sequential manner, which slows the whole process. Still, it's worth to keep those changes.

How to replicate issue mentioned above:
- introduce any changes in `*.py` file within `src` module
- run pre-commit through `make` command
- try to commit those changes
- comapre :3

*peepo-dev flies away*